### PR TITLE
Fix incorrect parameter names in MessagesSample widget

### DIFF
--- a/sample_app/lib/messages.dart
+++ b/sample_app/lib/messages.dart
@@ -42,7 +42,7 @@ class MessagesSample extends StatelessWidget {
             Navigator.of(context).pop();
           }
         },
-        appBarOptions: (user, group, context) {
+        trailingView : (user, group, context) {
           if (group != null) {
             return [
               IconButton(
@@ -106,7 +106,7 @@ class MessagesSample extends StatelessWidget {
                 child: CometChatMessageList(
                   user: user,
                   group: group,
-                  showAvatar: true,
+                  avatarVisibility: true,
                   onThreadRepliesClick: (message, context, {template}) {
                     Navigator.push(
                       context,


### PR DESCRIPTION
**Changes Made:**

* **Replaced deprecated `appBarOptions` with `trailingView`** in `CometChatMessageHeader`:

  * `trailingView` is now correctly used to display action buttons (info icons) based on whether the user is in a group or direct chat.
* **Updated `showAvatar` to `avatarVisibility`** in `CometChatMessageList`:

  * Ensures avatars are properly displayed next to chat bubbles as per the latest CometChat Flutter UI Kit API.


